### PR TITLE
Snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ npm-debug.log.*
 # vim swap files
 *.swp
 
+# ctags file
+tags
+
 # file system junk
 .DS_Store
 thumbs.db

--- a/src/db/SCHEMA.md
+++ b/src/db/SCHEMA.md
@@ -1,0 +1,23 @@
+# Database Schema
+Or something like that...
+
+## Survivors
+TODO
+
+## Settlements
+TODO
+
+## Snapshots
+
+Base Settlement Object:
+1. Tied to exactly one settlement (and only of the survs in smt)
+1. Tied to a lantern year created (should be only one per lantern year, but not enforced) -- note that this is the lanternYear property of the settlement it is tied to
+1. Holds the settlement object at time of snapshot
+1. Holds the survivor objects in settlement at time of snapshot
+
+IDEA:
+- Every lantern year, on `depart`, a new snapshot is created for the current state of things
+- NeDB gives it a unique .\_id
+- Vuex stores a `snapshotID` property in the store
+  * if `null`, then NOT in history mode -- everything is editable, etc, carry on
+  * else, in history mode! All getters related to displaying content (i.e. `currentSettlement`, `survivorsInSettlement`, etc.) all return the objects from the snapshot

--- a/src/db/snapshots.js
+++ b/src/db/snapshots.js
@@ -1,0 +1,31 @@
+import Database from './db'
+
+class SnapshotsDatabase extends Database {
+  constructor (dbpath, smtsdb, survsdb) {
+    // NOTE: takes in both the settlements and survivors db
+    super(dbpath, 'snapshots.db')
+    this.smtsdb = smtsdb
+    this.survsdb = survsdb
+  }
+
+  createNew (smtID, cb) {
+    // Get the settlement object
+    this.smtsdb.getMatching({ _id: smtID }, (smts) => {
+      if (smts.length === 0) {
+        throw new Error('Tried to add base survivor for non-existant settlement!')
+      }
+
+      // create a new snapshot with settlement
+      var snapshot = { settlement: smts[0] }
+
+      // Get all of the survivors...
+      this.survsdb.getMatching({ settlementID: smtID }, (survs) => {
+        // save survivors
+        snapshot.survivors = survs
+
+        // add snapshot to db
+        super.createNew(snapshot, cb)
+      })
+    })
+  }
+}

--- a/src/db/snapshots.js
+++ b/src/db/snapshots.js
@@ -29,3 +29,4 @@ class SnapshotsDatabase extends Database {
     })
   }
 }
+export default SnapshotsDatabase

--- a/src/renderer/components/KDMApp.vue
+++ b/src/renderer/components/KDMApp.vue
@@ -9,6 +9,7 @@
         <span>|NAV| |BAR| |HERE|</span>
         <survivor-table id="survivor-table"></survivor-table>
         <button @click="createSnapshot(currentSmt)">Create Snapshot</button>
+        <button @click="setCurrentSnap(null)">Leave Snapshot Mode</button>
         <br>
         <button v-for="snap in snapshotsForCurrentSettlement" @click="setCurrentSnap(snap._id)">
           {{ snap.settlement.name }} at LY {{ snap.settlement.lanternYear }}
@@ -42,7 +43,10 @@ export default {
     ...mapGetters(['snapshotsForCurrentSettlement'])
   },
   methods: {
-    ...mapActions(['createSnapshot', 'setCurrentSnap']),
+    ...mapActions([
+      'createSnapshot',
+      'setCurrentSnap'
+    ]),
     play: function () {
       if (this.currentSmt !== null) {
         this.appState = 1

--- a/src/renderer/components/KDMApp.vue
+++ b/src/renderer/components/KDMApp.vue
@@ -8,6 +8,11 @@
       <div id="content">
         <span>|NAV| |BAR| |HERE|</span>
         <survivor-table id="survivor-table"></survivor-table>
+        <button @click="createSnapshot(currentSmt)">Create Snapshot</button>
+        <br>
+        <button v-for="snap in snapshotsForCurrentSettlement" @click="setCurrentSnap(snap._id)">
+          {{ snap.settlement.name }} at LY {{ snap.settlement.lanternYear }}
+        </button>
       </div>
       <div id="note-panel">
         <span style="font-weight: bold">Notes:</span>
@@ -22,7 +27,7 @@ import WelcomeScreen from './WelcomeScreen'
 import SurvivorTable from './SurvivorTable'
 import SettlementInspector from './SettlementInspector'
 import NotePanel from './NotePanel'
-import { mapState } from 'vuex'
+import { mapState, mapGetters, mapActions } from 'vuex'
 
 export default {
   name: 'kdm-app',
@@ -33,11 +38,11 @@ export default {
     }
   },
   computed: {
-    ...mapState([
-      'currentSmt'
-    ])
+    ...mapState(['currentSmt']),
+    ...mapGetters(['snapshotsForCurrentSettlement'])
   },
   methods: {
+    ...mapActions(['createSnapshot', 'setCurrentSnap']),
     play: function () {
       if (this.currentSmt !== null) {
         this.appState = 1

--- a/src/renderer/components/KDMApp.vue
+++ b/src/renderer/components/KDMApp.vue
@@ -47,8 +47,10 @@ export default {
     }
   },
   mounted: function () {
+    // load all db's
     this.$store.dispatch('loadSettlements')
     this.$store.dispatch('loadSurvivors')
+    this.$store.dispatch('loadSnapshots')
   }
 }
 </script>

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -7,6 +7,7 @@ import store from './store'
 
 import SurvivorsDatabase from '../db/survivors'
 import SettlementsDatabase from '../db/settlements'
+import SnapshotsDatabase from '../db/snapshots'
 
 import { remote } from 'electron'
 
@@ -17,12 +18,15 @@ Vue.config.productionTip = false
 console.log(remote.app.getPath('userData'))
 var smts = new SettlementsDatabase(remote.app.getPath('userData'))
 var survs = new SurvivorsDatabase(remote.app.getPath('userData'), smts)
+var snaps = new SnapshotsDatabase(remote.app.getPath('userData'), smts, survs)
 
 Vue.prototype.$settlements = smts
 Vue.prototype.$survivors = survs
+Vue.prototype.$snapshots = snaps
 
 store.$settlements = smts
 store.$survivors = survs
+store.$snapshots = snaps
 
 /* eslint-disable no-new */
 new Vue({

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -14,7 +14,9 @@ export default new Vuex.Store({
   state: {
     survivors: [],
     settlements: [],
-    currentSmt: null
+    snapshots: [],
+    currentSmt: null,
+    currentSnap: null
   },
   getters: {
     survivorsInSettlement: (state) => {
@@ -39,6 +41,9 @@ export default new Vuex.Store({
     },
     settlementFemaleCount: (state) => {
       return countSurvivorsInSmtWPropVal(state.survivors, state.currentSmt, 'sex', 'f')
+    },
+    snapshotsForCurrentSettlement: (state) => {
+      return state.snapshots.filter((s) => { return s.settlement._id === state.currentSmt })
     }
   },
   mutations: {
@@ -48,8 +53,14 @@ export default new Vuex.Store({
     SET_SETTLEMENTS (state, newObj) {
       state.settlements = newObj
     },
+    SET_SNAPSHOTS (state, newObj) {
+      state.snapshots = newObj
+    },
     SET_CURRENTSMT (state, id) {
       state.currentSmt = id
+    },
+    SET_CURRENTSNAP (state, id) {
+      state.currentSnap = id
     },
     // Needs Vue.set --> https://vuejs.org/v2/guide/list.html#Caveats
     SET_SETTLEMENT_BY_ID (state, payload) {
@@ -65,16 +76,25 @@ export default new Vuex.Store({
     setCurrentSmt ({ commit }, id) {
       commit('SET_CURRENTSMT', id)
     },
+
     loadSettlements ({ commit }) {
       this.$settlements.getAll((smts) => {
         commit('SET_SETTLEMENTS', smts)
       })
     },
+
     loadSurvivors ({ commit }) {
       this.$survivors.getAll((survs) => {
         commit('SET_SURVIVORS', survs)
       })
     },
+
+    loadSnapshots ({ commit }) {
+      this.$snapshots.getAll((snaps) => {
+        commit('SET_SNAPSHOTS', snaps)
+      })
+    },
+
     updateSettlement ({ commit }, payload) {
       var id = payload.id
       var update = payload.update
@@ -87,6 +107,7 @@ export default new Vuex.Store({
         })
       })
     },
+
     createSettlement ({ commit }) {
       this.$settlements.createNew(() => {
         this.$settlements.getAll((smts) => {
@@ -94,6 +115,7 @@ export default new Vuex.Store({
         })
       })
     },
+
     deleteSettlement ({ commit }, id) {
       this.$settlements.remove(id, () => {
         this.$settlements.getAll((smts) => {
@@ -102,6 +124,7 @@ export default new Vuex.Store({
         })
       })
     },
+
     dropAllSurvivors ({ commit }) {
       this.$survivors.dropAll(() => {
         this.$survivors.getAll((survs) => {
@@ -109,6 +132,7 @@ export default new Vuex.Store({
         })
       })
     },
+
     addNewSurvivor ({ commit }, smtID) {
       console.log(smtID)
       this.$survivors.addBase(smtID, { name: 'Test' }, () => {
@@ -117,6 +141,7 @@ export default new Vuex.Store({
         })
       })
     },
+
     updateSurvivor ({ commit }, payload) {
       var id = payload.id
       var update = payload.update
@@ -125,6 +150,18 @@ export default new Vuex.Store({
           commit('SET_SURVIVOR_BY_ID', { id: s[0]._id, newObj: s[0] })
         })
       })
+    },
+
+    createSnapshot ({ commit }, smtID) {
+      this.$snapshots.createNew(smtID, () => {
+        this.$snapshots.getAll((snaps) => {
+          commit('SET_SNAPSHOTS', snaps)
+        })
+      })
+    },
+
+    setCurrentSnap ({ commit }, id) {
+      commit('SET_CURRENTSNAP', id)
     }
   },
   strict: process.env.NODE_ENV !== 'production'

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -117,7 +117,10 @@ export default new Vuex.Store({
       })
     },
 
-    updateSettlement ({ commit }, payload) {
+    updateSettlement ({ state, commit }, payload) {
+      // ignore if in snapshot mode!
+      // TODO: decide if wanna handle this way!
+      if (state.currentSnap != null) { return }
       var id = payload.id
       var update = payload.update
       // update the smt in db
@@ -164,7 +167,8 @@ export default new Vuex.Store({
       })
     },
 
-    updateSurvivor ({ commit }, payload) {
+    updateSurvivor ({ state, commit }, payload) {
+      if (state.currentSnap != null) { return }
       var id = payload.id
       var update = payload.update
       this.$survivors.updateOne(id, update, () => {

--- a/test/snapshotsdb-test.js
+++ b/test/snapshotsdb-test.js
@@ -1,0 +1,73 @@
+import SurvivorsDatabase from '../src/db/survivors.js'
+import SettlementsDatabase from '../src/db/settlements.js'
+import SnapshotsDatabase from '../src/db/snapshots.js'
+
+describe('Snapshots', () => {
+  var settlements
+  var survivors
+  var snapshots
+  before(function() {
+    // Instantiate dbs
+    settlements = new SettlementsDatabase('test_data')
+    settlements.dropAll()
+    survivors = new SurvivorsDatabase('test_data', settlements)
+    survivors.dropAll()
+    snapshots = new SnapshotsDatabase('test_data', settlements, survivors)
+    snapshots.dropAll()
+
+    // Create the test settlement
+    settlements.createNew((smt) => {
+      settlements.updateOne(smt._id, { name: 'Test' })
+    })
+  })
+
+  after(function() {
+    // NOT Compacting dbs -- it seems to be causing async errors when run w other tests
+    // survivors.loadDatabase()
+    // settlements.loadDatabase()
+    // snapshots.loadDatabase()
+  })
+
+  describe('Snapshot Not Altered 1', () => {
+    it('Empty survivors snapshot still empty after add survivor', (done) => {
+      settlements.getAll((docs) => {
+        var smtID = docs[0]._id
+        // Create snapshot
+        snapshots.createNew(smtID, (doc) => {
+          // Add survivor
+          survivors.addBase(smtID, {}, () => {
+            // Check snapshot is empty
+            snapshots.getMatching({ _id: doc._id }, (docs) => {
+              if (docs[0].survivors.length === 0) done()
+              else done(new Error())
+            })
+          })
+        })
+      })
+    })
+  })
+
+
+  describe('Snapshot Not Altered 2', () => {
+    it('Editing survivor obj in snapshot doesnt change snapshot', (done) => {
+      settlements.getAll((docs) => {
+        var smtID = docs[0]._id
+        // Create snapshot
+        snapshots.createNew(smtID, (doc) => {
+          var snapID = doc._id
+          // Get survivor
+          survivors.getAll((docs) => {
+            // Update
+            survivors.updateOne(docs[0]._id, { name: 'Alex' }, () => {
+              // Check snapshot is unchaged
+              snapshots.getMatching({ _id: snapID }, (docs) => {
+                if (docs[0].survivors[0].name == null) done()
+                else done(new Error())
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/survivorsdb-test.js
+++ b/test/survivorsdb-test.js
@@ -17,7 +17,8 @@ describe('Survivors', () => {
   })
 
   after(function() {
-    // Compact db
+    // Compact dbs
+    settlements.loadDatabase()
     survivors.loadDatabase()
   })
 


### PR DESCRIPTION
## Motivation

We've been talking about adding a history view of each survivor and the settlement, a cool way to go back through time to see survivors in their prime, and see the settlement when it was young.

Enter snapshots.

## What

A snapshot is just a **fixed** encapsulation of a settlement object and an array of survivor objects:

```js
snapshot = {
  _id: '123',
  settlement: { _id: ... },
  survivors: [{ ... }, ...]
}
```

## When

A snapshot currently is created manually by hitting a button (I threw a demo together at the bottom of the survivor table), but, in the future it will be every time you depart!

## What this all Means

Vuex now has a list of all snapshots (and a getter for those pertinent to the current settlement) and a `currentSnap` property.  If the `currentSnap` is NOT null, then **the selected snapshot overrides all current getters (`survivorsInSettlement`, `currentSettlement`,...) thus making the app show the past snapshot**.

In addition, if a snapshot is selected, then `updateSurvivor` and `updateSettlement` are blocked so that any attempted changes to history don't mess with things.

NOTE: selecting a snapshot **does not change the current survivors list in the state or the settlements list**, it simply changes which is returned by the getters until no snapshot is selected.

This is, I believe, the cleanest way to incorporate snapshots, but I'm open to feedback!

## Demo

As discussed before, there is a demo at the bottom of the settlement table (the snapshots are selectable / createable via buttons) -- check it out!