### PR TITLE
Autocomplete Everywhere (!)

### DIFF
--- a/src/renderer/components/GUIComponents/EditableList.vue
+++ b/src/renderer/components/GUIComponents/EditableList.vue
@@ -1,7 +1,15 @@
 <template>
   <div class="editable-list-wrapper">
     <ul class="editable-list">
-      <editable-list-item v-for="(item, index) in listItems" :initTextValue="item" :placeholder="placeholder + ' ' + (index + 1)" :key="index" @update="updateItem(index, $event)" @delete="deleteItem(index)"></editable-list-item>
+      <editable-list-item
+        v-for="(item, index) in listItems"
+        :initTextValue="item"
+        :placeholder="placeholder + ' ' + (index + 1)"
+        :key="index"
+        :autocompleteList="['abc', 'abcd', 'abcdefg', 'bde', 'bdefg', 'b']"
+        @update="updateItem(index, $event)"
+        @delete="deleteItem(index)" >
+      </editable-list-item>
     </ul>
     <button v-if="!max || listItems.length < max" class="add-item" @click="addNew">+</button>
   </div>

--- a/src/renderer/components/GUIComponents/EditableList.vue
+++ b/src/renderer/components/GUIComponents/EditableList.vue
@@ -6,7 +6,7 @@
         :initTextValue="item"
         :placeholder="placeholder + ' ' + (index + 1)"
         :key="index"
-        :autocompleteList="['abc', 'abcd', 'abcdefg', 'bde', 'bdefg', 'b']"
+        :autocompleteList="autocompleteList"
         @update="updateItem(index, $event)"
         @delete="deleteItem(index)" >
       </editable-list-item>
@@ -25,7 +25,8 @@ export default {
     listItems: { required: true },
     max: { required: false, default: null },
     min: { required: false, default: null },
-    placeholder: { required: false, default: 'Item' }
+    placeholder: { required: false, default: 'Item' },
+    autocompleteList: { default: () => [] }
   },
   created: function () {
     // Deal with case where min is specified but

--- a/src/renderer/components/GUIComponents/EditableListItem.vue
+++ b/src/renderer/components/GUIComponents/EditableListItem.vue
@@ -2,7 +2,15 @@
   <div>
     <li class="editable-list-item" @mouseover="hover = true" @mouseleave="hover = false">
       <div class="item-input-wrapper" :class="{'input-on-hover' : (hover && !editing)}">
-        <editable-text-input :textValue="initTextValue" :textStyle="{textOverflow: 'ellipsis'}" :placeholder="placeholder" @update="$emit('update', $event)" @focus="editing = true" @blur="editing = false" />
+        <editable-text-input
+          :textValue="initTextValue"
+          :textStyle="{textOverflow: 'ellipsis'}"
+          :placeholder="placeholder"
+          :autocompleteList="autocompleteList"
+          @update="$emit('update', $event)"
+          @focus="editing = true"
+          @blur="editing = false"
+          />
       </div>
       <font-awesome-icon v-if="hover && !editing" :icon="deleteIcon" class="delete-icon" @click="$emit('delete')" @mousedown="mouseDownOnDelete = true" @mouseup="mouseDownOnDelete = false" @mouseleave="mouseDownOnDelete = false" />
     </li>
@@ -20,6 +28,7 @@ export default {
   components: { EditableTextInput, FontAwesomeIcon },
   props: {
     initTextValue: { required: true },
+    autocompleteList: { default: () => [] },
     placeholder: { required: true }
   },
   data: function () {

--- a/src/renderer/components/GUIComponents/EditableTextInput.vue
+++ b/src/renderer/components/GUIComponents/EditableTextInput.vue
@@ -22,7 +22,8 @@
       <div
         v-for="(item, index) in filteredList"
         :class="['autocomplete-item', index === filteredIdx ? 'activeComplete' : '']"
-        @mouseover="filteredIdx = index">
+        @mouseover="filteredIdx = index"
+        @mouseleave="filteredIdx = -1" >
         {{ item }}
       </div>
     </div>
@@ -93,7 +94,6 @@ export default {
     },
 
     selectCompletion: function () {
-      console.log('sC')
       if (this.filteredIdx > -1 && this.filteredIdx < this.filteredList.length) {
         // update!
         this.$emit('update', this.filteredList[this.filteredIdx])
@@ -104,7 +104,6 @@ export default {
     },
 
     selectCompletionAndExit: function () {
-      console.log('sC&E')
       this.selectCompletion()
       this.$refs.eIn.blur()
     }

--- a/src/renderer/components/GUIComponents/EditableTextInput.vue
+++ b/src/renderer/components/GUIComponents/EditableTextInput.vue
@@ -24,7 +24,12 @@
         :class="['autocomplete-item', index === filteredIdx ? 'activeComplete' : '']"
         @mouseover="filteredIdx = index"
         @mouseleave="filteredIdx = -1" >
-        {{ item }}
+        <div v-if="textValue != null">
+        <b>{{ item.substring(0, textValue.length) }}</b>{{ item.substring(textValue.length) }}
+        </div>
+        <div v-else>
+          {{ item }}
+        </div>
       </div>
     </div>
   </div>

--- a/src/renderer/components/GUIComponents/EditableTextInput.vue
+++ b/src/renderer/components/GUIComponents/EditableTextInput.vue
@@ -1,7 +1,32 @@
 <template>
   <div>
-  <input class="editable-text-input" ref="eIn" :placeholder="placeholder" :type="inputType" :style="editableStyle" :value="textValue" @mouseover="hover = true" @mouseleave="hover = false" @focus="focus = true; $emit('focus')" @blur="focus = false; $emit('blur')" @keyup.enter="$refs.eIn.blur()" @input="$emit('update', $event.target.value)" />
-</div>
+    <input
+      class="editable-text-input"
+      ref="eIn"
+      :placeholder="placeholder"
+      :type="inputType"
+      :style="editableStyle"
+      :value="textValue"
+      @mouseover="hover = true"
+      @mouseleave="hover = false"
+      @focus="focus = true; $emit('focus')"
+      @blur="focus = false; $emit('blur'); selectCompletion()"
+      @keyup.enter="selectCompletionAndExit()"
+      @input="$emit('update', $event.target.value)"
+      @keyup.down.prevent="downList()"
+      @keyup.up.prevent="upList()"
+      @keydown.tab.prevent
+      @keyup.tab.prevent="selectCompletion()" />
+
+    <div v-if="filteredList.length > 0 && focus" class="autocomplete-list">
+      <div
+        v-for="(item, index) in filteredList"
+        :class="['autocomplete-item', index === filteredIdx ? 'activeComplete' : '']"
+        @mouseover="filteredIdx = index">
+        {{ item }}
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -11,13 +36,15 @@ export default {
     placeholder: { required: false, default: 'Text...' },
     textValue: { required: true },
     textStyle: { default: null },
-    inputType: { default: 'text' }
+    inputType: { default: 'text' },
+    autocompleteList: { default: () => [] } // need function so not all have same list!
   },
   data: function () {
     return {
       bgImgUrl: 'static/pencil.png',
       hover: false,
-      focus: false
+      focus: false,
+      filteredIdx: -1
     }
   },
   computed: {
@@ -39,6 +66,47 @@ export default {
       } else {
         return this.textStyle
       }
+    },
+
+    filteredList: function () {
+      if (this.textValue == null) {
+        return this.autocompleteList
+      }
+      return this.autocompleteList.filter((s) => {
+        return s.substring(0, this.textValue.length) === this.textValue
+      })
+    }
+  },
+  methods: {
+    upList: function () {
+      // decrement idx
+      if (this.filteredIdx > -1) {
+        this.filteredIdx--
+      }
+    },
+
+    downList: function () {
+      // update idx
+      if (this.filteredIdx < this.filteredList.length - 1) {
+        this.filteredIdx++
+      }
+    },
+
+    selectCompletion: function () {
+      console.log('sC')
+      if (this.filteredIdx > -1 && this.filteredIdx < this.filteredList.length) {
+        // update!
+        this.$emit('update', this.filteredList[this.filteredIdx])
+
+        // reset idx
+        this.filteredIdx = -1
+      }
+    },
+
+    selectCompletionAndExit: function () {
+      console.log('sC&E')
+      this.selectCompletion()
+      this.$refs.eIn.blur()
     }
   }
 }
@@ -63,5 +131,28 @@ input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
+}
+
+.autocomplete-list {
+  position: absolute;
+  background: white;
+  border-style: solid;
+  border-width: 2px;
+  z-index: 99;
+}
+
+.autocomplete-item {
+  border-style: solid;
+  border-width: 1px;
+  padding-left: 3px;
+  width: 100px;
+}
+
+.autocomplete-item:hover {
+  background-color: gray;
+}
+
+.activeComplete {
+  background-color: gray;
 }
 </style>

--- a/src/renderer/components/GUIComponents/EditableTextInput.vue
+++ b/src/renderer/components/GUIComponents/EditableTextInput.vue
@@ -75,8 +75,8 @@ export default {
     },
 
     okayToShowAutocomplete: function () {
-      // check that >= 1 character in text
-      if (this.textValue !== null && this.textValue.length > 0) {
+      // check that >= 1 character in text (or already in list -- allows down arrow)
+      if (this.filteredIdx > -1 || (this.textValue !== null && this.textValue.length > 0)) {
         // check filtered list has stuff + focus on
         if (this.focus && this.filteredList.length > 0) {
           return true

--- a/src/renderer/components/GUIComponents/EditableTextInput.vue
+++ b/src/renderer/components/GUIComponents/EditableTextInput.vue
@@ -138,6 +138,8 @@ input::-webkit-inner-spin-button {
   border-style: solid;
   border-width: 2px;
   z-index: 99;
+  max-height: 120px;
+  overflow-y: scroll;
 }
 
 .autocomplete-item {

--- a/src/renderer/components/GUIComponents/EditableTextInput.vue
+++ b/src/renderer/components/GUIComponents/EditableTextInput.vue
@@ -18,7 +18,7 @@
       @keydown.tab.prevent
       @keyup.tab.prevent="selectCompletion()" />
 
-    <div v-if="filteredList.length > 0 && focus" class="autocomplete-list">
+    <div v-if="okayToShowAutocomplete" class="autocomplete-list">
       <div
         v-for="(item, index) in filteredList"
         :class="['autocomplete-item', index === filteredIdx ? 'activeComplete' : '']"
@@ -72,6 +72,17 @@ export default {
       } else {
         return this.textStyle
       }
+    },
+
+    okayToShowAutocomplete: function () {
+      // check that >= 1 character in text
+      if (this.textValue !== null && this.textValue.length > 0) {
+        // check filtered list has stuff + focus on
+        if (this.focus && this.filteredList.length > 0) {
+          return true
+        }
+      }
+      return false
     },
 
     filteredList: function () {

--- a/src/renderer/components/SettlementInspector.vue
+++ b/src/renderer/components/SettlementInspector.vue
@@ -24,19 +24,35 @@
     </p>
     <p>
       <b>Principles: </b>
-      <editable-list :listItems="currentSettlement.principles" :max="4" @update="update('principles', $event)"></editable-list>
+      <editable-list
+        :listItems="currentSettlement.principles"
+        :max="4"
+        :autocompleteList="principleNames"
+        @update="update('principles', $event)"
+        ></editable-list>
     </p>
     <p>
       <b>Locations: </b>
-      <editable-list :listItems="currentSettlement.locations" @update="update('locations', $event)"></editable-list>
+      <editable-list
+        :listItems="currentSettlement.locations"
+        :autocompleteList="['Lantern Hoard', 'Stone Circle', 'Weapon Crafter']"
+        @update="update('locations', $event)"
+        ></editable-list>
     </p>
     <p>
       <b>Innovations: </b>
-      <editable-list :listItems="currentSettlement.innovations" @update="update('innovations', $event)"></editable-list>
+      <editable-list
+        :listItems="currentSettlement.innovations"
+        :autocompleteList="innovationNames"
+        @update="update('innovations', $event)"
+        ></editable-list>
     </p>
     <p>
       <b>Quarries: </b>
-      <editable-list :listItems="currentSettlement.quarries" @update="update('quarries', $event)"></editable-list>
+      <editable-list
+        :listItems="currentSettlement.quarries"
+        :autocompleteList="['White Lion', 'Screaming Antelope', 'Pheonix']"
+        @update="update('quarries', $event)"></editable-list>
     </p>
   </div>
 </template>
@@ -44,6 +60,11 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 import { EditableList } from './GUIComponents'
+import { Innovations, BaseInnovations, Principles } from '../assets/StaticGameData'
+
+function getNames (obj) {
+  return Object.values(obj).map((o) => { return o.name })
+}
 
 export default {
   name: 'settlement-inspector',
@@ -55,7 +76,14 @@ export default {
       'settlementMaleCount',
       'settlementFemaleCount',
       'currentSettlement'
-    ])
+    ]),
+    principleNames: function () {
+      return getNames(Principles)
+    },
+    innovationNames: function () {
+      return getNames(Innovations).concat(getNames(BaseInnovations))
+    }
+
   },
   methods: {
     ...mapActions([

--- a/src/renderer/components/SettlementInspector.vue
+++ b/src/renderer/components/SettlementInspector.vue
@@ -60,7 +60,7 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 import { EditableList } from './GUIComponents'
-import { Innovations, BaseInnovations, Principles } from '../assets/StaticGameData'
+import { Innovations, Principles } from '../assets/StaticGameData'
 
 function getNames (obj) {
   return Object.values(obj).map((o) => { return o.name })
@@ -81,7 +81,7 @@ export default {
       return getNames(Principles)
     },
     innovationNames: function () {
-      return getNames(Innovations).concat(getNames(BaseInnovations))
+      return getNames(Innovations)
     }
 
   },

--- a/src/renderer/components/SurvivorModal.vue
+++ b/src/renderer/components/SurvivorModal.vue
@@ -151,7 +151,14 @@
                 <span class="title">Fighting Arts</span>
                 <span class="subtitle">Max 3.</span>
               </div>
-              <editable-list :listItems="survivor.fightingArts" :min="3" :max="3" :placeholder="'Fighting Art'" @update="update($event, 'fightingArts')" />
+              <editable-list
+                :listItems="survivor.fightingArts"
+                :min="3"
+                :max="3"
+                :placeholder="'Fighting Art'"
+                :autocompleteList="fightingArtNames"
+                @update="update($event, 'fightingArts')"
+                />
             </div>
             <div class="cannot-fight"><lock-toggle :statDisplayName="'Cannot Use Fighting Arts'" :initValue="survivor.cannotUseFighting" @update="update($event, 'cannotUseFighting')" /></div>
           </div>
@@ -160,7 +167,14 @@
               <span class="title">Disorders</span>
               <span class="subtitle">Max 3.</span>
             </div>
-            <editable-list :listItems="survivor.disorders" :min="3" :max="3" :placeholder="'Disorder'" @update="update($event, 'disorders')" />
+            <editable-list
+              :listItems="survivor.disorders"
+              :min="3"
+              :max="3"
+              :placeholder="'Disorder'"
+              :autocompleteList="disorderNames"
+              @update="update($event, 'disorders')"
+              />
           </div>
           <div class="abilities row5box">
             <div class="row5title">
@@ -236,6 +250,7 @@ import {
   LockToggle,
   EditableList
 } from './GUIComponents'
+import { Disorders, FightingArts } from '../assets/StaticGameData'
 
 export default {
   name: 'survivor-modal',
@@ -286,6 +301,12 @@ export default {
       } else {
         return 'Survivor is currently resting in the settlement.'
       }
+    },
+    fightingArtNames: function () {
+      return Object.values(FightingArts).map((o) => { return o.name })
+    },
+    disorderNames: function () {
+      return Object.values(Disorders).map((o) => { return o.name })
     }
   },
   methods: {


### PR DESCRIPTION
## Why

There's a lot of long and complex names in this game, and it is nice to save a few key strokes here and there (and typos).

## Introducing Autocomplete... Everywhere!

I call it _Autocomplete Everywhere_ because I've altered the `EditableTextInput` component introduced by the beautiful #6 so that it can take in a list of autocomplete selections (optional). If it does, then the following behavior happens:

1. Down/Up arrows navigate through an autocomplete popdown of the filtered list passed in (filtered by what is written in the input)
2. Tab will accept what the dropdown has selected but allow continued typing
3. Enter will accept + blur (causing dropdown to close)
4. Clicking on items works as well! (same as enter)

NOTE: The autocomplete window does **not** open until **at least one character is typed**; however, the user can **still use the arrow keys to see the full list, even if blank input**.

## The Future

Put it (even more) everywhere! @mws96 was kind enough to put in game assets for disorders, fighting arts, innovations, and principles, but there can be more! Get creative!

### TODO:

- [x] More Assets
    - [x] Locations
    - [x] Impairments
    - [x] Quarries
- [ ] Autocomplete names of survivors (Vuex getter) for intimacy, etc
- [ ] Integrate autocomplete with the tagging system (a TODO itself)