### PR TITLE
Introducing History Mode

### DIFF
--- a/src/db/snapshots.js
+++ b/src/db/snapshots.js
@@ -8,15 +8,18 @@ class SnapshotsDatabase extends Database {
     this.survsdb = survsdb
   }
 
-  createNew (smtID, cb) {
+  createNew (smtID, noteID, cb) {
     // Get the settlement object
     this.smtsdb.getMatching({ _id: smtID }, (smts) => {
       if (smts.length === 0) {
         throw new Error('Tried to add base survivor for non-existant settlement!')
       }
 
-      // create a new snapshot with settlement
-      var snapshot = { settlement: smts[0] }
+      // create a new snapshot with settlement and noteID
+      var snapshot = {
+        settlement: smts[0],
+        noteID: noteID
+      }
 
       // Get all of the survivors...
       this.survsdb.getMatching({ settlementID: smtID }, (survs) => {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -11,5 +11,8 @@
 </script>
 
 <style>
-  /* CSS */
+/* Global CSS */
+.DISABLE-CLICKS-HISTORY-MODE {
+  pointer-events: none;
+}
 </style>

--- a/src/renderer/components/GUIComponents/EditableList.vue
+++ b/src/renderer/components/GUIComponents/EditableList.vue
@@ -17,12 +17,19 @@
         @delete="deleteItem(index)" >
       </editable-list-item>
     </ul>
-    <button v-if="!max || listItems.length < max" class="add-item" @click="addNew">+</button>
+    <button
+      v-if="!max || listItems.length < max"
+      class="add-item"
+      :disabled="inHistoryMode"
+      @click="addNew">
+      +
+    </button>
   </div>
 </template>
 
 <script>
 import EditableListItem from './EditableListItem'
+import { mapGetters } from 'vuex'
 
 export default {
   name: 'editable-list',
@@ -37,6 +44,9 @@ export default {
     numberEditable: { required: false, default: true, type: Boolean },
     textStyle: { required: false, default: () => { return { fontSize: '10pt' } } },
     parentHeight: { required: false, default: 9999 }
+  },
+  computed: {
+    ...mapGetters(['inHistoryMode'])
   },
   created: function () {
     // Deal with case where min is specified but

--- a/src/renderer/components/GUIComponents/EditableListItem.vue
+++ b/src/renderer/components/GUIComponents/EditableListItem.vue
@@ -8,7 +8,7 @@
         :value="count"
         type="number"
         :style="{fontSize:textStyle.fontSize}"
-        :disabled="!numberEditable"
+        :disabled="inHistoryMode || !numberEditable"
         @input="$emit('updateCount', $event.target.value)">
       </input>
       <div class="item-input-wrapper" :class="{'input-on-hover' : (hover && !editing)}">
@@ -43,6 +43,7 @@ import FontAwesomeIcon from '@fortawesome/vue-fontawesome'
 import { faTimesCircle as farTimesCircle } from '@fortawesome/fontawesome-free-regular'
 import { faTimesCircle as fasTimesCircle } from '@fortawesome/fontawesome-free-solid'
 import EditableTextInput from './EditableTextInput'
+import { mapGetters } from 'vuex'
 
 export default {
   name: 'editable-list-item',
@@ -65,6 +66,7 @@ export default {
     }
   },
   computed: {
+    ...mapGetters(['inHistoryMode']),
     deleteIcon: function () {
       if (this.mouseDownOnDelete) {
         return fasTimesCircle

--- a/src/renderer/components/GUIComponents/EditableStat.vue
+++ b/src/renderer/components/GUIComponents/EditableStat.vue
@@ -3,7 +3,16 @@
     <div class="increment-box" @mouseover="hover = true" @mouseleave="hover = false">
       <div class="chevron top"><font-awesome-icon :icon="chevronUp" :class="[topBounce ? 'animated bounce' : '']" :style="chevronStyle" @mousedown="updateStat(statValue + 1); bounceTop()" /></div>
       <div :class="{ maxbox : limitBox }">
-        <input type="number" class="statbox" :class="{ borderless : limitBox, 'no-border': noBorder }" :value="statValue" @input="updateStat($event.target.value)" @focus="$event.target.select(); focus = true" @blur="focus = false" @keydown.enter="$event.target.blur()" />
+        <input
+        type="number"
+        class="statbox"
+        :class="{ borderless : limitBox, 'no-border': noBorder }"
+        :disabled="inHistoryMode"
+        :value="statValue"
+        @input="updateStat($event.target.value)"
+        @focus="$event.target.select(); focus = true"
+        @blur="focus = false"
+        @keydown.enter="$event.target.blur()" />
         <span v-if="limitBox" class="limitbox"><div class="limit-label">Limit</div>{{ maxValue }}</span>
       </div>
       <div v-if="statDisplayName" class="stat-display-name" :style="displayNameStyle">{{ statDisplayName }}</div>
@@ -15,6 +24,7 @@
 <script>
 import FontAwesomeIcon from '@fortawesome/vue-fontawesome'
 import { faChevronUp, faChevronDown } from '@fortawesome/fontawesome-free-solid'
+import { mapGetters } from 'vuex'
 
 export default {
   name: 'editable-stat',
@@ -42,6 +52,7 @@ export default {
     }
   },
   computed: {
+    ...mapGetters(['inHistoryMode']),
     chevronUp: function () {
       return faChevronUp
     },
@@ -177,28 +188,28 @@ input::-webkit-inner-spin-button {
   animation-timing-function: linear;
   animation-iteration-count: 1;
   -webkit-animation-iteration-count: 1;
-} 
+}
 @-webkit-keyframes bounce {
   0%, 100% {-webkit-transform: translateY(0);}
   50% {-webkit-transform: translateY(-5px);}
-} 
-@keyframes bounce { 
+}
+@keyframes bounce {
   0%, 100% {transform: translateY(0);}
   50% {transform: translateY(-5px);}
-} 
-.bounce { 
+}
+.bounce {
   -webkit-animation-name: bounce;
   animation-name: bounce;
 }
 @-webkit-keyframes bounceDown {
   0%, 100% {-webkit-transform: translateY(0);}
   50% {-webkit-transform: translateY(5px);}
-} 
-@keyframes bounceDown { 
+}
+@keyframes bounceDown {
   0%, 100% {transform: translateY(0);}
   50% {transform: translateY(5px);}
-} 
-.bounceDown { 
+}
+.bounceDown {
   -webkit-animation-name: bounceDown;
   animation-name: bounceDown;
 }

--- a/src/renderer/components/GUIComponents/EditableStat.vue
+++ b/src/renderer/components/GUIComponents/EditableStat.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="editable-stat">
+  <div 
+    :class="[ inHistoryMode ? 'DISABLE-CLICKS-HISTORY-MODE' : '' ]"
+    class="editable-stat">
     <div class="increment-box" @mouseover="hover = true" @mouseleave="hover = false">
       <div class="chevron top"><font-awesome-icon :icon="chevronUp" :class="[topBounce ? 'animated bounce' : '']" :style="chevronStyle" @mousedown="updateStat(statValue + 1); bounceTop()" /></div>
       <div :class="{ maxbox : limitBox }">
@@ -7,7 +9,6 @@
         type="number"
         class="statbox"
         :class="{ borderless : limitBox, 'no-border': noBorder }"
-        :disabled="inHistoryMode"
         :value="statValue"
         @input="updateStat($event.target.value)"
         @focus="$event.target.select(); focus = true"

--- a/src/renderer/components/GUIComponents/EditableTextInput.vue
+++ b/src/renderer/components/GUIComponents/EditableTextInput.vue
@@ -5,6 +5,7 @@
       ref="eIn"
       :placeholder="placeholder"
       :type="inputType"
+      :disabled="inHistoryMode"
       :style="editableStyle"
       :value="textValue"
       @mouseover="hover = true"
@@ -43,6 +44,8 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
+
 export default {
   name: 'editable-text-input',
   props: {
@@ -93,6 +96,7 @@ export default {
     obs.observe(this.$root.$el, { childList: true, subtree: true })
   },
   computed: {
+    ...mapGetters(['inHistoryMode']),
     editableStyle: function () {
       if (this.focus) {
         return {

--- a/src/renderer/components/GUIComponents/LockToggle.vue
+++ b/src/renderer/components/GUIComponents/LockToggle.vue
@@ -1,5 +1,7 @@
 <template>
-  <div @click="toggleState = !toggleState; $emit('update', toggleState)">
+  <div 
+    :class="[ inHistoryMode ? 'DISABLE-CLICKS-HISTORY-MODE' : '' ]"
+    @click="toggleState = !toggleState; $emit('update', toggleState)">
     <div class="flex-wrapper">
       <div><div class="lock" :class="lockClass"><font-awesome-icon :icon="icon" /></div></div>
       <div class="lock-toggle-text">{{ statDisplayName }}</div>
@@ -10,6 +12,7 @@
 <script>
 import FontAwesomeIcon from '@fortawesome/vue-fontawesome'
 import { faLock, faLockOpen } from '@fortawesome/fontawesome-free-solid'
+import { mapGetters } from 'vuex'
 
 export default {
   name: 'lock-toggle',
@@ -24,6 +27,7 @@ export default {
     }
   },
   computed: {
+    ...mapGetters(['inHistoryMode']),
     icon: function () {
       if (this.toggleState) {
         return faLock

--- a/src/renderer/components/GUIComponents/SquareToggle.vue
+++ b/src/renderer/components/GUIComponents/SquareToggle.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="square-toggle" :style="titleSize" @click="toggle()">
+  <div
+    :class="[ inHistoryMode ? 'DISABLE-CLICKS-HISTORY-MODE' : '' ]"
+    class="square-toggle"
+    :style="titleSize"
+    @click="toggle()">
     <div class="flex-wrapper">
       <div :class="[checkValue ? 'square' : 'empty-square']" :style="toggleSize"></div><div class="toggle-title">{{ statDisplayName }}</div>
     </div>
@@ -7,6 +11,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 export default {
   name: 'square-toggle',
   props: {
@@ -25,6 +30,7 @@ export default {
     }
   },
   computed: {
+    ...mapGetters(['inHistoryMode']),
     toggleSize: function () {
       var toggleStyle = {}
       toggleStyle['width'] = this.squareSize + 'px'
@@ -67,5 +73,9 @@ export default {
   margin: 0px 2px;
   cursor: pointer;
   transition: background-color 0.3s ease;
+}
+div.square-inactive {
+   pointer-events: none;
+   cursor: default;
 }
 </style>

--- a/src/renderer/components/GUIComponents/SquareToggle.vue
+++ b/src/renderer/components/GUIComponents/SquareToggle.vue
@@ -74,8 +74,4 @@ export default {
   cursor: pointer;
   transition: background-color 0.3s ease;
 }
-div.square-inactive {
-   pointer-events: none;
-   cursor: default;
-}
 </style>

--- a/src/renderer/components/KDMApp.vue
+++ b/src/renderer/components/KDMApp.vue
@@ -9,7 +9,7 @@
         <div class="tabbar">
           <button
             class="tab-button"
-            @click="appState = 0">
+            @click="appState = 0; leaveHistoryMode()">
             <font-awesome-icon :icon="homeIcon" />
           </button>
           <button
@@ -53,7 +53,7 @@
       <div
         v-if="inHistoryMode"
         class="history-bar"
-        @click="setCurrentSnap(null)" >
+        @click="leaveHistoryMode" >
         You are in <strong>History Mode</strong>! Click banner to exit, otherwise, look around!
       </div>
       <div v-if="inHistoryMode" class="history-dimmer"></div>
@@ -105,7 +105,7 @@ export default {
     }
   },
   methods: {
-    ...mapActions(['setCurrentSnap']),
+    ...mapActions(['leaveHistoryMode']),
     play: function () {
       if (this.currentSmt !== null) {
         this.appState = 1

--- a/src/renderer/components/KDMApp.vue
+++ b/src/renderer/components/KDMApp.vue
@@ -51,12 +51,12 @@
         <notes-tab v-if="notesOpen"/>
       </transition>
       <div
-        v-if="currentSnap != null"
+        v-if="inHistoryMode"
         class="history-bar"
         @click="setCurrentSnap(null)" >
         You are in <strong>History Mode</strong>! Click banner to exit, otherwise, look around!
       </div>
-      <div v-if="currentSnap != null" class="history-dimmer"></div>
+      <div v-if="inHistoryMode" class="history-dimmer"></div>
     </div>
   </div>
 </template>
@@ -68,7 +68,7 @@ import SettlementInspector from './SettlementInspector'
 import SettlementStorage from './Storage'
 import SettlementTimeline from './Timeline'
 import NotesTab from './NotesTab'
-import { mapState, mapActions } from 'vuex'
+import { mapState, mapActions, mapGetters } from 'vuex'
 
 import FontAwesomeIcon from '@fortawesome/vue-fontawesome'
 import { faHome, faWindowClose, faBook } from '@fortawesome/fontawesome-free-solid'
@@ -92,10 +92,8 @@ export default {
     }
   },
   computed: {
-    ...mapState([
-      'currentSmt',
-      'currentSnap'
-    ]),
+    ...mapState(['currentSmt']),
+    ...mapGetters(['inHistoryMode']),
     homeIcon: function () {
       return faHome
     },

--- a/src/renderer/components/KDMApp.vue
+++ b/src/renderer/components/KDMApp.vue
@@ -54,7 +54,7 @@
         v-if="inHistoryMode"
         class="history-bar"
         @click="leaveHistoryMode" >
-        You are in <strong>History Mode</strong>! Click banner to exit, otherwise, look around!
+        You are in <strong>History Mode</strong>! Click this banner to exit, otherwise, look around!
       </div>
       <div v-if="inHistoryMode" class="history-dimmer"></div>
     </div>

--- a/src/renderer/components/KDMApp.vue
+++ b/src/renderer/components/KDMApp.vue
@@ -56,6 +56,7 @@
         @click="setCurrentSnap(null)" >
         You are in <strong>History Mode</strong>! Click banner to exit, otherwise, look around!
       </div>
+      <div v-if="currentSnap != null" class="history-dimmer"></div>
     </div>
   </div>
 </template>
@@ -205,5 +206,19 @@ div.history-bar {
   text-align: center;
   color: white;
   line-height: 36px;
+  user-select: none;
+  cursor: default;
+  z-index: 1000;
+}
+div.history-dimmer {
+  background-color: #A9A9A9;
+  opacity: .4;
+  position: absolute;
+  left: 0px;
+  top: 0px;
+  width: 100%;
+  height: 100%;
+  z-index: 999;
+  pointer-events: none;  /* send clicks thru */
 }
 </style>

--- a/src/renderer/components/KDMApp.vue
+++ b/src/renderer/components/KDMApp.vue
@@ -50,6 +50,12 @@
       <transition name="slide">
         <notes-tab v-if="notesOpen"/>
       </transition>
+      <div
+        v-if="currentSnap != null"
+        class="history-bar"
+        @click="setCurrentSnap(null)" >
+        You are in <strong>History Mode</strong>! Click banner to exit, otherwise, look around!
+      </div>
     </div>
   </div>
 </template>
@@ -61,7 +67,7 @@ import SettlementInspector from './SettlementInspector'
 import SettlementStorage from './Storage'
 import SettlementTimeline from './Timeline'
 import NotesTab from './NotesTab'
-import { mapState } from 'vuex'
+import { mapState, mapActions } from 'vuex'
 
 import FontAwesomeIcon from '@fortawesome/vue-fontawesome'
 import { faHome, faWindowClose, faBook } from '@fortawesome/fontawesome-free-solid'
@@ -85,7 +91,10 @@ export default {
     }
   },
   computed: {
-    ...mapState(['currentSmt']),
+    ...mapState([
+      'currentSmt',
+      'currentSnap'
+    ]),
     homeIcon: function () {
       return faHome
     },
@@ -97,6 +106,7 @@ export default {
     }
   },
   methods: {
+    ...mapActions(['setCurrentSnap']),
     play: function () {
       if (this.currentSmt !== null) {
         this.appState = 1
@@ -184,5 +194,16 @@ button.notes-button {
 }
 .slide-enter, .slide-leave-to {
   transform: translateX(300px);
+}
+div.history-bar {
+  background-color: gray;
+  position: absolute;
+  left: 0px;
+  bottom: 0px;
+  width: 100%;
+  height: 36px;
+  text-align: center;
+  color: white;
+  line-height: 36px;
 }
 </style>

--- a/src/renderer/components/KDMApp.vue
+++ b/src/renderer/components/KDMApp.vue
@@ -36,14 +36,6 @@
         </div>
         <div v-if="currentTab === 'survivors'" class="tab-survivors">
           <survivor-table id="survivor-table" />
-          <button @click="createSnapshot(currentSmt)">Create Snapshot</button>
-          <button @click="setCurrentSnap(null)">Leave Snapshot Mode</button>
-          <br>
-          <button
-            v-for="snap in snapshotsForCurrentSettlement"
-            @click="setCurrentSnap(snap._id)">
-            {{ snap.settlement.name }} at LY {{ snap.settlement.lanternYear }}
-          </button>
         </div>
         <div v-if="currentTab === 'storage'" class="tab-storage">
           <settlement-storage />
@@ -69,7 +61,7 @@ import SettlementInspector from './SettlementInspector'
 import SettlementStorage from './Storage'
 import SettlementTimeline from './Timeline'
 import NotesTab from './NotesTab'
-import { mapState, mapGetters, mapActions } from 'vuex'
+import { mapState } from 'vuex'
 
 import FontAwesomeIcon from '@fortawesome/vue-fontawesome'
 import { faHome, faWindowClose, faBook } from '@fortawesome/fontawesome-free-solid'
@@ -94,7 +86,6 @@ export default {
   },
   computed: {
     ...mapState(['currentSmt']),
-    ...mapGetters(['snapshotsForCurrentSettlement']),
     homeIcon: function () {
       return faHome
     },
@@ -106,10 +97,6 @@ export default {
     }
   },
   methods: {
-    ...mapActions([
-      'createSnapshot',
-      'setCurrentSnap'
-    ]),
     play: function () {
       if (this.currentSmt !== null) {
         this.appState = 1

--- a/src/renderer/components/NotesTab.vue
+++ b/src/renderer/components/NotesTab.vue
@@ -3,19 +3,33 @@
     <h2>Notes</h2>
     <textarea
       class="notes-input"
+      :disabled="inHistoryMode"
       placeholder="What happened this year?"
       v-model="currNote"
       >
     </textarea>
 
-    <button class="add-note" @click="addNote"> + </button>
+    <button
+      class="add-note"
+      :disabled="inHistoryMode"
+      @click="addNote">
+      +
+    </button>
 
     <div v-if="currentSettlement.notes.length > 0">
       <h3>Past Notes:</h3>
       <div v-for="(note, index) in sortedNotes" class="past-note">
         <b> Lantern Year {{ note.lanternYear }} </b>
-        <button class="delete-note" @click="deleteNote(index)">x</button>
-        <button class="delete-note" @click="setCurrentSnapByLanternYearAndNoteID({ ly: note.lanternYear, noteID: note._id })">
+        <button
+          class="delete-note"
+          :disabled="inHistoryMode"
+          @click="deleteNote(index)">
+          x
+        </button>
+        <button
+          class="delete-note"
+          :disabled="inHistoryMode"
+          @click="setCurrentSnapByLanternYearAndNoteID({ ly: note.lanternYear, noteID: note._id })">
           <font-awesome-icon :icon="histIcon"/>
         </button>
         <br>
@@ -39,7 +53,10 @@ export default {
   name: 'notes-tab',
   components: { FontAwesomeIcon },
   computed: {
-    ...mapGetters(['currentSettlement']),
+    ...mapGetters([
+      'inHistoryMode',
+      'currentSettlement'
+    ]),
     sortedNotes: function () {
       var notesClone = JSON.parse(JSON.stringify(this.currentSettlement.notes))
       return notesClone.sort((a, b) => { return b.time - a.time })

--- a/src/renderer/components/NotesTab.vue
+++ b/src/renderer/components/NotesTab.vue
@@ -14,6 +14,9 @@
       <div v-for="(note, index) in sortedNotes" class="past-note">
         <b> Lantern Year {{ note.lanternYear }} </b>
         <button class="delete-note" @click="deleteNote(index)">x</button>
+        <button class="delete-note" @click="setCurrentSnapByLanternYear(note.lanternYear)">
+          <font-awesome-icon :icon="histIcon"/>
+        </button>
         <br>
         {{ note.body }}
         <br>
@@ -28,14 +31,20 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
+import FontAwesomeIcon from '@fortawesome/vue-fontawesome'
+import { faHistory } from '@fortawesome/fontawesome-free-solid'
 
 export default {
   name: 'notes-tab',
+  components: { FontAwesomeIcon },
   computed: {
     ...mapGetters(['currentSettlement']),
     sortedNotes: function () {
       var notesClone = JSON.parse(JSON.stringify(this.currentSettlement.notes))
       return notesClone.sort((a, b) => { return b.time - a.time })
+    },
+    histIcon: function () {
+      return faHistory
     }
   },
   data: function () {
@@ -44,7 +53,10 @@ export default {
     }
   },
   methods: {
-    ...mapActions(['updateSettlement']),
+    ...mapActions([
+      'updateSettlement',
+      'setCurrentSnapByLanternYear'
+    ]),
     addNote: function () {
       var d = new Date()
       var dateStr = d.toLocaleDateString() + ' ' + d.toLocaleTimeString()
@@ -59,6 +71,7 @@ export default {
       this.updateSettlement({ id: this.currentSettlement._id, update: { notes: oldNotes } })
       this.currNote = ''
     },
+
     deleteNote: function (idx) {
       var oldNotes = JSON.parse(JSON.stringify(this.sortedNotes))
       oldNotes.splice(idx, 1)

--- a/src/renderer/components/NotesTab.vue
+++ b/src/renderer/components/NotesTab.vue
@@ -7,14 +7,15 @@
       v-model="currNote"
       >
     </textarea>
-      <button class="add-note" @click="addNote"> + </button>
+
+    <button class="add-note" @click="addNote"> + </button>
 
     <div v-if="currentSettlement.notes.length > 0">
       <h3>Past Notes:</h3>
       <div v-for="(note, index) in sortedNotes" class="past-note">
         <b> Lantern Year {{ note.lanternYear }} </b>
         <button class="delete-note" @click="deleteNote(index)">x</button>
-        <button class="delete-note" @click="setCurrentSnapByLanternYear(note.lanternYear)">
+        <button class="delete-note" @click="setCurrentSnapByLanternYearAndNoteID({ ly: note.lanternYear, noteID: note._id })">
           <font-awesome-icon :icon="histIcon"/>
         </button>
         <br>
@@ -55,12 +56,14 @@ export default {
   methods: {
     ...mapActions([
       'updateSettlement',
-      'setCurrentSnapByLanternYear'
+      'setCurrentSnapByLanternYearAndNoteID',
+      'createSnapshot'
     ]),
     addNote: function () {
       var d = new Date()
       var dateStr = d.toLocaleDateString() + ' ' + d.toLocaleTimeString()
       var fullNote = {
+        _id: 'id_' + Date.now(),
         body: this.currNote,
         time: Date.now(),
         timeStr: dateStr,
@@ -70,6 +73,9 @@ export default {
       oldNotes.push(fullNote)
       this.updateSettlement({ id: this.currentSettlement._id, update: { notes: oldNotes } })
       this.currNote = ''
+
+      // create snapshot with this noteID!
+      this.createSnapshot({ smtID: this.currentSettlement._id, noteID: fullNote._id })
     },
 
     deleteNote: function (idx) {

--- a/src/renderer/components/SettlementInspector.vue
+++ b/src/renderer/components/SettlementInspector.vue
@@ -5,13 +5,28 @@
     <b>Overview:</b>
     <br>
       Lantern Year:
-      <input class="value" :value="currentSettlement.lanternYear" :stat="'lanternYear'" @input="updateNumberValue"/>
+      <input
+        class="value"
+        :value="currentSettlement.lanternYear"
+        :disabled="inHistoryMode"
+        :stat="'lanternYear'"
+        @input="updateNumberValue"/>
     <br>
       Survival Limit:
-      <input class="value" :value="currentSettlement.survivalLimit" :stat="'survivalLimit'" @input="updateNumberValue"/>
+      <input
+        class="value"
+        :value="currentSettlement.survivalLimit"
+        :stat="'survivalLimit'"
+        :disabled="inHistoryMode"
+        @input="updateNumberValue"/>
     <br>
       Survival on Depart:
-      <input class="value" :value="currentSettlement.survivalOnDepart" :stat="'survivalOnDepart'" @input="updateNumberValue"/>
+      <input
+        class="value"
+        :value="currentSettlement.survivalOnDepart"
+        :stat="'survivalOnDepart'"
+        :disabled="inHistoryMode"
+        @input="updateNumberValue"/>
     </p>
     <p>
     <b>Stats:</b>
@@ -98,6 +113,7 @@ export default {
   },
   computed: {
     ...mapGetters([
+      'inHistoryMode',
       'numberAliveInSettlement',
       'settlementDeathCount',
       'settlementMaleCount',

--- a/src/renderer/components/SurvivorComponents/AliveToggle.vue
+++ b/src/renderer/components/SurvivorComponents/AliveToggle.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="alive-wrapper" @click="toggle()">
+  <div 
+    :class="[ inHistoryMode ? 'DISABLE-CLICKS-HISTORY-MODE' : '' ]"
+    class="alive-wrapper"
+    @click="toggle()">
     <div class="flex-wrapper">
       <div><div class="alive-toggle" :class="[toggleState ? 'alive' : 'dead']"><font-awesome-icon :icon="icon" /></div></div>
       <div class="alive-toggle-text"><span v-if="toggleState">Alive</span><span v-else>Dead</span></div>
@@ -31,6 +34,7 @@ export default {
   },
   computed: {
     ...mapGetters([
+      'inHistoryMode',
       'currentSettlement'
     ]),
     icon: function () {

--- a/src/renderer/components/SurvivorComponents/MaleFemaleToggle.vue
+++ b/src/renderer/components/SurvivorComponents/MaleFemaleToggle.vue
@@ -1,18 +1,23 @@
 <template>
-  <div class="mf-toggle">
+  <div 
+    :class="[ inHistoryMode ? 'DISABLE-CLICKS-HISTORY-MODE' : '' ]"
+    class="mf-toggle">
     M <div :class="[sex === 'm' ? 'square' : 'empty-square']" @click="setSex('m')"></div>
     F <div :class="[sex === 'f' ? 'square' : 'empty-square']" @click="setSex('f')"></div>
   </div>
 </template>
 
 <script>
-import { mapActions } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
 
 export default {
   name: 'male-female-toggle',
   props: {
     initSex: { required: true },
     survivorID: { required: true }
+  },
+  computed: {
+    ...mapGetters(['inHistoryMode'])
   },
   data: function () {
     return {

--- a/src/renderer/components/SurvivorComponents/ProgressBar.vue
+++ b/src/renderer/components/SurvivorComponents/ProgressBar.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="progress-bar">
+  <div
+    :class="[ inHistoryMode ? 'DISABLE-CLICKS-HISTORY-MODE' : '' ]"
+    class="progress-bar" >
     <span v-if="!inline && title" class="title above">{{ title }} ({{ level }}): </span>
     <div class="flex-wrapper">
       <span v-if="inline && title" class="title" :style="{minWidth: String(4 + maxLevel / 8) + 'em'}">{{ title }} ({{ level }}): </span>
@@ -10,7 +12,7 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
 
 export default {
   name: 'progress-bar',
@@ -29,6 +31,9 @@ export default {
     return {
       level: this.initLevel
     }
+  },
+  computed: {
+    ...mapGetters(['inHistoryMode'])
   },
   methods: {
     ...mapActions([

--- a/src/renderer/components/SurvivorModal.vue
+++ b/src/renderer/components/SurvivorModal.vue
@@ -39,6 +39,7 @@
           <div class="death-label">Died LY:</div><div class="death-year"><editable-text-input :inputType="'number'" :textValue="survivor.deathYear" :textStyle="{width:'1.4em', fontSize: '10pt', border: '1px solid black', borderRadius: '2px',  textAlign: 'center', backgroundPosition: 'left 2px center'}" :placeholder="''" @update="update('deathYear', $event); update('alive', false)" /></div>
           <div v-if="survivor.alive" class="depart-button-wrapper">
             <button class="depart-button"
+              :disabled="inHistoryMode"
               :class="[survivor.departing ? 'green' : '']"
               @click="setDeparting(!survivor.departing)"
               @dblclick.stop @mousedown.stop>
@@ -322,6 +323,7 @@ export default {
   },
   computed: {
     ...mapGetters([
+      'inHistoryMode',
       'currentSettlement',
       'settlementDepartingCount',
       'survivorsInSettlement'

--- a/src/renderer/components/SurvivorModal.vue
+++ b/src/renderer/components/SurvivorModal.vue
@@ -256,7 +256,10 @@
           <div class="row6title">
             <span>Other information:</span>
           </div>
-          <textarea :value="survivor.other" @input="update('other', $event.target.value)"></textarea>
+          <textarea
+            :class="[ inHistoryMode ? 'DISABLE-CLICKS-HISTORY-MODE' : '' ]"
+            :value="survivor.other"
+            @input="update('other', $event.target.value)"></textarea>
         </div>
       </div>
     </div>

--- a/src/renderer/components/SurvivorTable.vue
+++ b/src/renderer/components/SurvivorTable.vue
@@ -9,8 +9,18 @@
         :initSelected="filter"
         title="Filter: "
         @selected="filter = $event" />
-      <button @click="resetDeparting" class="reset-departing-button right-start">Reset Departing</button>
-      <button @click="newSurvivor()" class="add-button">Add Survivor</button>
+      <button
+        :disabled="inHistoryMode"
+        @click="resetDeparting"
+        class="reset-departing-button right-start">
+        Reset Departing
+      </button>
+      <button
+        :disabled="inHistoryMode"
+        @click="newSurvivor()"
+        class="add-button">
+        Add Survivor
+      </button>
     </div>
     <div class="sort-controls flex-wrapper">
       <div class="sort-title">Sort:</div>
@@ -244,6 +254,7 @@ export default {
       'currentSmt'
     ]),
     ...mapGetters([
+      'inHistoryMode',
       'survivorsInSettlement',
       'settlementDepartingCount',
       'currentSettlement'

--- a/src/renderer/components/SurvivorTableRow.vue
+++ b/src/renderer/components/SurvivorTableRow.vue
@@ -32,7 +32,12 @@
             </button>
           </div>
           <div class="delete-button-wrapper">
-            <button class="delete-button" @click="deleteModalVisible = true" @dblclick.stop @mousedown.stop>
+            <button
+              :disabled="inHistoryMode"
+              class="delete-button"
+              @click="deleteModalVisible = true"
+              @dblclick.stop
+              @mousedown.stop>
               <font-awesome-icon :icon="deleteIcon" />
             </button>
           </div>
@@ -54,6 +59,7 @@
                 </div>
                 <div class="alive-button-wrapper">
                   <button class="alive-button"
+                    :disabled="inHistoryMode"
                     :class="[survivor.alive ? 'red' : '']"
                     @click="update('alive', !survivor.alive)"
                     @dblclick.stop @mousedown.stop>
@@ -62,6 +68,7 @@
                 </div>
                 <div v-if="survivor.alive" class="depart-button-wrapper">
                   <button class="depart-button"
+                    :disabled="inHistoryMode"
                     :class="[survivor.departing ? 'green' : '']"
                     @click="setDeparting(!survivor.departing)"
                     @dblclick.stop @mousedown.stop>
@@ -298,6 +305,7 @@ export default {
   },
   computed: {
     ...mapGetters([
+      'inHistoryMode',
       'currentSettlement',
       'settlementDepartingCount'
     ]),

--- a/src/renderer/components/Timeline.vue
+++ b/src/renderer/components/Timeline.vue
@@ -19,7 +19,12 @@
       </tbody>
       <tr>
         <td class="button-wrapper">
-          <button class="add-button" @click="addYear()">+</button>
+          <button
+            class="add-button"
+            :disabled="inHistoryMode"
+            @click="addYear()">
+            +
+          </button>
         </td>
       </tr>
     </table>
@@ -35,6 +40,7 @@ export default {
   components: { TimelineYear },
   computed: {
     ...mapGetters([
+      'inHistoryMode',
       'currentSettlement'
     ])
   },

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -14,15 +14,17 @@ export default new Vuex.Store({
     currentSnap: null
   },
   getters: {
-    snapshotSurvivors: (state) => {
-      if (state.currentSnap == null) { return [] }
+    snapshotSurvivors: (state, getters) => {
+      if (!getters.inHistoryMode) {
+        return []
+      }
       var snap = state.snapshots.find((s) => { return s._id === state.currentSnap })
       return snap.survivors
     },
 
     // OUTWARD FACING -- takes into account snapshot (which overrides currentSmt)
     survivorsInSettlement: (state, getters) => {
-      if (state.currentSnap == null) {
+      if (!getters.inHistoryMode) {
         return state.survivors.filter((s) => { return s.settlementID === state.currentSmt })
       } else {
         return getters.snapshotSurvivors
@@ -34,15 +36,15 @@ export default new Vuex.Store({
       return survs.map((s) => { return goodnessFunction(s) })
     },
 
-    snapshotSettlement: (state) => {
-      if (state.currentSnap == null) { return {} }
+    snapshotSettlement: (state, getters) => {
+      if (!getters.inHistoryMode) { return {} }
       var snap = state.snapshots.find((s) => { return s._id === state.currentSnap })
       return snap.settlement
     },
 
     // OUTWARD FACING -- takes into account snapshot (which overrides currentSmt)
     currentSettlement: (state, getters) => {
-      if (state.currentSnap == null) {
+      if (!getters.inHistoryMode) {
         return state.settlements.find((s) => { return s._id === state.currentSmt })
       } else {
         return getters.snapshotSettlement
@@ -71,6 +73,10 @@ export default new Vuex.Store({
 
     snapshotsForCurrentSettlement: (state) => {
       return state.snapshots.filter((s) => { return s.settlement._id === state.currentSmt })
+    },
+
+    inHistoryMode: (state) => {
+      return state.currentSnap != null
     }
   },
   mutations: {
@@ -122,10 +128,9 @@ export default new Vuex.Store({
       })
     },
 
-    updateSettlement ({ state, commit }, payload) {
+    updateSettlement ({ state, commit, getters }, payload) {
       // ignore if in snapshot mode!
-      // TODO: decide if wanna handle this way!
-      if (state.currentSnap != null) { return }
+      if (getters.inHistoryMode) { return }
       var id = payload.id
       var update = payload.update
       // update the smt in db
@@ -184,10 +189,8 @@ export default new Vuex.Store({
       })
     },
 
-    updateSurvivor ({ state, commit }, payload) {
-      if (state.currentSnap != null) {
-        return
-      }
+    updateSurvivor ({ state, commit, getters }, payload) {
+      if (getters.inHistoryMode) { return }
       var id = payload.id
       var update = payload.update
       this.$survivors.updateOne(id, update, () => {
@@ -197,10 +200,8 @@ export default new Vuex.Store({
       })
     },
 
-    updateAllSurvivorsInSettlement ({ state, commit }, payload) {
-      if (state.currentSnap != null) {
-        return
-      }
+    updateAllSurvivorsInSettlement ({ state, commit, getters }, payload) {
+      if (getters.inHistoryMode) { return }
       var update = payload.update
       this.$survivors.updateSettlement(state.currentSmt, update, () => {
         this.$survivors.getAll((survs) => {

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -231,7 +231,7 @@ export default new Vuex.Store({
         console.log('setting snap to be of ly ' + String(ly))
         commit('SET_CURRENTSNAP', snapsOfLY[0]._id)
       } else {
-        console.log('no snap for currentSmt of requested LY.. resetting')
+        console.log('no snap for currentSmt of LY ' + String(ly) + '.. resetting')
         commit('SET_CURRENTSNAP', null)
       }
     },

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -222,6 +222,10 @@ export default new Vuex.Store({
       commit('SET_CURRENTSNAP', id)
     },
 
+    leaveHistoryMode ({ commit }) {
+      commit('SET_CURRENTSNAP', null)
+    },
+
     setCurrentSnapByLanternYearAndNoteID ({ getters, commit }, ids) {
       var snaps = getters.snapshotsForCurrentSettlement.filter((s) => {
         return s.noteID === ids.noteID && s.settlement.lanternYear === ids.ly

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -209,8 +209,8 @@ export default new Vuex.Store({
       })
     },
 
-    createSnapshot ({ commit }, smtID) {
-      this.$snapshots.createNew(smtID, () => {
+    createSnapshot ({ commit }, ids) {
+      this.$snapshots.createNew(ids.smtID, ids.noteID, () => {
         this.$snapshots.getAll((snaps) => {
           commit('SET_SNAPSHOTS', snaps)
         })
@@ -221,17 +221,26 @@ export default new Vuex.Store({
       commit('SET_CURRENTSNAP', id)
     },
 
+    setCurrentSnapByLanternYearAndNoteID ({ getters, commit }, ids) {
+      var snaps = getters.snapshotsForCurrentSettlement.filter((s) => {
+        return s.noteID === ids.noteID && s.settlement.lanternYear === ids.ly
+      })
+
+      if (snaps.length > 0) {
+        commit('SET_CURRENTSNAP', snaps[0]._id)
+      } else {
+        commit('SET_CURRENTSNAP', null)
+      }
+    },
+
     setCurrentSnapByLanternYear ({ getters, commit }, ly) {
       var snapsOfLY = getters.snapshotsForCurrentSettlement.filter((s) => {
         return s.settlement.lanternYear === ly
       })
 
-      // TODO: handle case w more than 1 other than just returning first?
       if (snapsOfLY.length > 0) {
-        console.log('setting snap to be of ly ' + String(ly))
         commit('SET_CURRENTSNAP', snapsOfLY[0]._id)
       } else {
-        console.log('no snap for currentSmt of LY ' + String(ly) + '.. resetting')
         commit('SET_CURRENTSNAP', null)
       }
     },

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -221,6 +221,21 @@ export default new Vuex.Store({
       commit('SET_CURRENTSNAP', id)
     },
 
+    setCurrentSnapByLanternYear ({ getters, commit }, ly) {
+      var snapsOfLY = getters.snapshotsForCurrentSettlement.filter((s) => {
+        return s.settlement.lanternYear === ly
+      })
+
+      // TODO: handle case w more than 1 other than just returning first?
+      if (snapsOfLY.length > 0) {
+        console.log('setting snap to be of ly ' + String(ly))
+        commit('SET_CURRENTSNAP', snapsOfLY[0]._id)
+      } else {
+        console.log('no snap for currentSmt of requested LY.. resetting')
+        commit('SET_CURRENTSNAP', null)
+      }
+    },
+
     deleteSurvivor ({ commit }, payload) {
       var id = payload.id
       this.$survivors.remove(id, () => {


### PR DESCRIPTION
## Wrapping an Old Feature

"History Mode" is not a new feature per se... its truly a wrapper on the snapshot feature introduced by #5 . In this PR, history mode does become its own creature though, and changes snapshots from being relatively unusable to tightly integrated with the UI.

## Enhancing Usability

### Notes Integration

The only place you'll be able to enter history mode (as of now) is the NotesTab. You'll notice that each note now has a history button along with the delete button. Clicking this button takes you back to **the exact moment that note was taken** thanks to a commit here that adds a noteID to each snapshot (creating a 1-1 correspondence!).

When in history mode, the screen dulls a bit, a banner appears at the bottom that allows exiting the mode, and what you can do is restricted. You should only be able to navigate through the views, not edit the data.

### Disabling Edits in the GUI

Previously, the snapshots guarded against changing data in the store simply by having a catch in the Vuex actions that would exit early if a snapshot was being displayed.

This turned out to be not the best solution, as it allowed users to edit the data showing (which would revert back jarringly eventually). As well, certain buttons (`Add Survivor`) request promises returned, and this could get messy.

For a much cleaner way of disabling user edits, I manually went through the code base and altered many of the components. Components that should not be active while in history mode can be disabled using the following:

1. if a `<button>` or `<input>` element:
```vue
<button :disabled="inHistoryMode">...
```
2. if a `<div>`, use the global CSS class:
```vue
<div :class="[ inHistoryMode ? 'DISABLE-CLICKS-HISTORY-MODE' : '' ]">...
```

**NOTE:** The `inHistoryMode` is a Vuex getter--this means it can be accessed simply by adding the following to the component:

```javascript
import { mapGetters } from 'vuex'

export default {
  name: ..
  ..
  computed: {
    ...mapGetters(['inHistoryMode']),
    ..
  }
  ..
}
```

## Looking Forward

The next step (which may or may not get pushed out by the time we decide to start advertising the app) will be adding a "timeline" for history mode. I really like the 1-1 between notes and snapshots, but I think adding a separate way to enter history mode (maybe an up arrow at the bottom of the screen) that presents a timeline bar for each lantern year (1 snapshot per year) that allows the user to scroll through time would be very cool!